### PR TITLE
Add redirect to main website

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,0 +1,98 @@
+# 1. Ilmenauer Open
+## Datum
+
+30.10.2025 – 02.11.2025
+
+## Spiellokal
+
+Sparkassenhalle (Schülerfreizeitzentrum)  
+Am Großen Teich 2, 98693 Ilmenau
+
+Google Maps: [https://maps.app.goo.gl/rZMkYBArJcAaS7RU7](https://maps.app.goo.gl/rZMkYBArJcAaS7RU7)
+
+## Bankverbindung
+
+- Ilmenauer Schachverein
+- IBAN: DE25 8405 1010 1124 0002 47
+- BIC: HELADEF1ILK
+- Kreditinstitut: Sparkasse Arnstadt-Ilmenau
+- Verwendungszweck: Spielername, OPEN2025
+- 35 € (10 € Rabatt für Rentner, Studenten – mit Nachweis, U18)
+- 10 € Aufschlag für Überweisungen nach dem 01. Oktober 2025
+
+## Auswertung
+
+- Das Schachturnier beeinflusst die DWZ (Deutsche Wertungszahl) und die ELO (FIDE) Zahl der Teilnehmer.
+- Jeder Spieler muss zum Zeitpunkt der Anmeldung über eine FIDE-ID verfügen. [FIDE-ID beantragen](https://www.schachbund.de/fide-identifikationsnummer.html)
+
+## Zeitplan
+
+| Datum      | Uhrzeit      | Ereignis      |
+| ---------- | ------------ | ------------- |
+| 30.10.2025 | Bis 08:30    | Anmeldung     |
+| 30.10.2025 | 09:00        | 1. Runde      |
+| 30.10.2025 | 15:00        | 2. Runde      |
+| 31.11.2025 | 09:00        | 3. Runde      |
+| 31.11.2025 | 15:00        | 4. Runde      |
+| 31.11.2025 | 20:15        | Blitz Turnier |
+| 01.11.2025 | 09:00        | 5. Runde      |
+| 01.11.2025 | 15:00        | 6. Runde      |
+| 02.11.2025 | 09:00        | 7. Runde      |
+| 02.11.2025 | anschließend | Siegerehrung  |
+
+- Die Karenzzeit beträgt 30 min.
+
+## Preise
+
+- Volle Preise ab 40 Teilnehmern
+- Keine Doppelvergabe
+
+| Gruppe       | Preis         |
+| ------------ | ------------- |
+| 1. Platz     | Pokal + 250 € |
+| 2. Platz     | Pokal + 150 € |
+| 3. Platz     | Pokal + 100 € |
+| U 1800 TWZ   | 50 €          |
+| U 1600 TWZ   | 50 €          |
+| U 1400 TWZ   | 50 €          |
+| U 1200 TWZ   | 50 €          |
+| 1. Platz U18 | Pokal         |
+| 1. Ilmenauer | Pokal         |
+| Held         | Pokal         |
+
+## Turniermodus
+
+- 7 Runden Schweizer System
+- 2 Stunden + 30 Sekunden pro Zug
+- Es besteht schreibpflicht
+- Das Original ist abzugeben. Der Durchschlag kann behalten werden.
+- Die Karrenzzeit beträgt 30 min ab Rundenbeginn. 
+
+## Startgeld
+
+- Die Anmeldung inkl. Geldeingang muss bis zum 12.10.2025 erfolgt sein
+- Maximal 80 Teilnehmer (Reihenfolge der Anmeldungen)
+- Mit der Anmeldung wird einer Photoerlaubnis zugestimmt.
+- Formular für die Anmeldung: [Anmeldung](https://open.ilmenauer-schachverein.de/2025/anmeldung/)
+
+## Rückerstattung
+
+Sollte sich ein Spieler vom Turnier vor Turnierbeginn abmelden, wird eine Bearbeitungsgebühr von 10 Euro erhoben und der restliche Beitrag nach dem Turnier zurücküberwiesen.
+
+## Kontakt
+
+Das 2. Ilmenauer Open 2025 und das 2. Ilmenauer Open Blitz 2025 sind Turniere, die vom [Ilmenauer SV](https://ilmenauer-schachverein.de) organisiert werden.
+
+### Kontaktmöglichkeiten:
+
+- E-Mail: [info@ilmenauer-schachverein.de](mailto:info@ilmenauer-schachverein.de)
+- Adresse: Ehrenbergstraße 29, 98693 Ilmenau
+
+
+### Hinweis
+
+Die Auswertung der Gruppen erfolgt von oben nach unten. Um eine doppelte Preisvergabe zu vermeiden, wird der Sieger einer Gruppe in den nachfolgenden Gruppen nicht mehr berücksichtigt.
+
+In den DWZ-Kategorien und beim Heldenpokal werden ausschließlich Teilnehmer berücksichtigt, die zu Turnierbeginn eine gültige DWZ hatten. Der Heldenpokal wird an den Teilnehmer vergeben, der älter als Jahrgang 2006 ist und gemäß Swiss-Chess die größte virtuelle DWZ-Steigerung erzielt hat, wobei die oben genannte Regelung zur Vermeidung von Doppelvergaben beachtet wird.
+
+Für die Preisvergabe gilt: Als U18 werden alle Teilnehmer gewertet, die Jahrgang 2006 oder jünger sind.

--- a/index.html
+++ b/index.html
@@ -1,4 +1,3 @@
-
 <!doctype html>
 <html lang="de">
 <head>
@@ -6,6 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Leer / Empty</title>
   <link rel="stylesheet" href="styles.css">
+
+  <meta http-equiv="refresh" content="0; url=https://ilmenauer-schachverein.de/">
+  <link rel="canonical" href="https://ilmenauer-schachverein.de/">
+
+  <script>
+    window.location.replace("https://ilmenauer-schachverein.de/");
+  </script>
 </head>
 <body>
   <main class="page">


### PR DESCRIPTION
Adds an automatic HTML and JavaScript redirect from the empty page to the main Ilmenauer Schachverein website while keeping the existing fallback link.